### PR TITLE
#14 - typo, #17 - Cannot set property of object which has only getter

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -59,6 +59,20 @@ describe('passive events are supported', () => {
       capture: false
     });
   });
+
+  it('should work when passing options object with getter-only passive property', () => {
+    var optionsWithPassiveGetter = {
+      get passive () {
+        return true;
+      }
+    };
+
+    document.addEventListener('click', handler, optionsWithPassiveGetter);
+    expect(addEventListenerSpy).toHaveBeenCalledWith('click', handler, {
+      passive: true,
+      capture: false
+    });
+  });
 });
 
 describe.skip('passive events are not supported', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const defaultOptions = {
   capture: false
 };
 const supportedPassiveTypes = [
-  'scroll', 'whell',
+  'scroll', 'wheel',
   'touchstart', 'touchmove', 'touchenter', 'touchend', 'touchleave',
   'mouseout', 'mouseleave', 'mouseup', 'mousedown', 'mousemove', 'mouseenter', 'mousewheel', 'mouseover'
 ];
@@ -13,14 +13,23 @@ const getDefaultPassiveOption = (passive, eventName) => {
   if (passive !== undefined) return passive;
 
   return supportedPassiveTypes.indexOf(eventName) === -1 ? false : defaultOptions.passive;
-}
+};
+
+const getWritableOptions = (options) => {
+  var passiveDescriptor = Object.getOwnPropertyDescriptor(options, 'passive');
+    
+  return passiveDescriptor && passiveDescriptor.writable !== true && passiveDescriptor.set === undefined
+    ? Object.assign({}, options)
+    : options;
+};
 
 const overwriteAddEvent = (superMethod) => {
   EventTarget.prototype.addEventListener = function(type, listener, options) {
     const usesListenerOptions = typeof options === 'object';
     const useCapture = usesListenerOptions ? options.capture : options;
 
-    options = usesListenerOptions ? options : {};
+    options = usesListenerOptions ? getWritableOptions(options) : {};
+
     options.passive = getDefaultPassiveOption(options.passive, type);
     options.capture = useCapture !== undefined ? useCapture : defaultOptions.capture;
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const getDefaultPassiveOption = (passive, eventName) => {
 };
 
 const getWritableOptions = (options) => {
-  var passiveDescriptor = Object.getOwnPropertyDescriptor(options, 'passive');
+  const passiveDescriptor = Object.getOwnPropertyDescriptor(options, 'passive');
     
   return passiveDescriptor && passiveDescriptor.writable !== true && passiveDescriptor.set === undefined
     ? Object.assign({}, options)

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,8 +8,8 @@ export const eventListenerOptionsSupported = () => {
       }
     });
 
-    window.addEventListener("test", null, opts);
-    window.removeEventListener("test", null, opts);
+    window.addEventListener('test', null, opts);
+    window.removeEventListener('test', null, opts);
   } catch (e) {}
 
   return supported;


### PR DESCRIPTION
Fixes:
zzarcon/default-passive-events#14
zzarcon/default-passive-events#17

Fixed typo in 'wheel' event name.

Added getWritableOptions function which checks if property 'passive' of an event options object is getter-only and if so shallow copies options with use of Object.assign method.

Added test which checks correctness of change described above.

Unificated use of apostrophes/quotation marks in strings primitives declaration - now whole lib uses quotation marks.
  