### PR TITLE
fix: avoid publishing the lock file that make the package size large

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,7 @@
     "microbundle": "^0.12.2"
   },
   "files": [
-    "dist/",
-    "src/",
-    "LICENSE",
-    "yarn.lock"
+    "dist",
   ],
   "jest": {
     "resetMocks": true


### PR DESCRIPTION
Fix #58